### PR TITLE
Fixed error on removing tables with foreign key constraints on test db

### DIFF
--- a/core/src/db/db.js
+++ b/core/src/db/db.js
@@ -223,10 +223,18 @@ export const resetMysqlDb = async () => {
 
     try {
         const [tables] = await db.query("SHOW TABLES");
+        
+        // Disable foreign key checks to allow truncating tables with dependencies
+        await db.query("SET FOREIGN_KEY_CHECKS = 0");
+
         for (const row of tables) {
             const tableName = Object.values(row)[0];
             await db.query(`DROP TABLE \`${tableName}\``);
         }
+
+        // Re-enable foreign key checks
+        await db.query("SET FOREIGN_KEY_CHECKS = 1");
+        
         console.log('MySQL database reset successfully');
     } catch (error) {
         console.error('Error resetting MySQL database: ' + error.message);


### PR DESCRIPTION
Issue:
  - When running gnar dev up --core-dev --test-service <service-name> after tests have ran, tables are being disposed, but when a table has a FOREIGN KEY constrain it throws an error and does not delete it.

Fix:
  - SET  FOREIGN_KEY_CHECKS = 0 (before removing tables)
  - SET FOREIGN_KEY_CHEKS = 1 (after removing tables)