### PR TITLE
Added the option to pass content parsers so fastify can accept other …

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnar-engine/core",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Gnar Engine - Service Core",
   "type": "module",
   "main": "dist/core.js",

--- a/core/src/controllers/http.controller.js
+++ b/core/src/controllers/http.controller.js
@@ -29,6 +29,13 @@ export const httpController = {
         if (config?.rateLimiting?.max && config?.rateLimiting?.timeWindow) {
             http.register(rateLimit, config.rateLimiting);
         }
+
+        // Additional content type parsers, Fastify has native support for 'application/json' and 'text/plain' only.
+        const contentTypeParsers = new Map((config.contentTypeParsers || []).map(parser => [parser.contentType, parser]));
+
+        contentTypeParsers.forEach(parser => {
+            http.addContentTypeParser(parser.contentType, { parseAs: parser.parseAs }, parser.parseFunction);
+        });
     },
 
     registerRoutes: ({controllers}) => {


### PR DESCRIPTION
## Support additional content type parsers

### Why

Fastify parses `application/json` and `text/plain` only. Core registers no parsers of its own, so anything else a service is sent gets rejected before the route's handler or preHandler runs — Fastify's `Unsupported Media Type`, which our error handler surfaces as a 500.

Services could not fix this themselves. `httpController` exposes `init`, `registerRoutes`, `addHook`, `getServer`, `start` and `setErrorHandler`, and `getServer()` returns the raw Node server, not the Fastify instance — so there was no way to reach `addContentTypeParser`. Any service needing a wider content type required a core change.

The first case is the opayo service: a 3D Secure ACS returns the cardholder to our callback as a browser form post, `application/x-www-form-urlencoded`.

### What changed

`httpController.init` now registers whatever a service declares in `config.http.contentTypeParsers`:

```js
// Additional content type parsers, Fastify has native support for 'application/json' and 'text/plain' only.
const contentTypeParsers = new Map((config.contentTypeParsers || []).map(parser => [parser.contentType, parser]));

contentTypeParsers.forEach(parser => {
    http.addContentTypeParser(parser.contentType, { parseAs: parser.parseAs }, parser.parseFunction);
});
```

Core stays agnostic — it knows no content type by name and adds no dependency. Each service supplies its own parser, so a service needing XML or CSV later needs no further core change. The `Map` is keyed on `contentType` because Fastify throws at boot if the same one is registered twice.

**Nothing changes for existing services.** Without `contentTypeParsers` in its config, a service behaves exactly as before.

### How to use it from a service

In the service's `config.js`, under `http`:

```js
import { parse } from 'node:querystring';

// ...
    http: {
        allowedOrigins: [ ... ],
        allowedMethods: ['GET', 'POST', 'PUT', 'DELETE'],
        allowedHeaders: ['Content-Type', 'Authorization'],

        // A 3D Secure ACS returns the cardholder to our callback with a browser form post,
        // which Fastify will not read without this.
        contentTypeParsers: [
            {
                contentType: 'application/x-www-form-urlencoded',
                parseAs: 'string',
                parseFunction: (request, body, done) => {
                    try {
                        done(null, parse(body));
                    } catch (err) {
                        err.statusCode = 400;
                        done(err, undefined);
                    }
                }
            }
        ],

        rateLimiting: { ... }
    },
```

The parsed value becomes `request.body`. That's all — core picks it up at `init`, before routes are registered.

Three things to know:

- `contentType` must be the full type. `application/x-www-form-urlencoded`, not `x-www-form-urlencoded`.
- **Parsers are instance-level, not per-route.** Declaring one widens every route in that service. Each route's own policy preHandler still applies.
- Prefer `querystring.parse` over `URLSearchParams` for form bodies — it returns an array for a repeated key, where `Object.fromEntries(new URLSearchParams(...))` silently keeps only the last value.

### Verified

Against a localdev api service

| request | before | after |
|---|---|---|
| form POST, `/api/endpoint/` | 500 `Unsupported Media Type` | 403, reaches the policy |
| json POST, `/api/endpoint/` | 403 | 403, unchanged |
| form `leaseId`, lease the user owns | — | 400, policy read `leaseId` off the parsed body |
| form POST to a service with no `contentTypeParsers` | 500 | 500, unchanged |